### PR TITLE
chore(audit): sync CONTRIBUTING.md and CLAUDE.md with template

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,7 +19,7 @@ docs: clarify deployment steps
 
 ## Branching and PRs
 
-- `main` is protected by a ruleset (see [`docs/BRANCH_PROTECTION.md`](docs/BRANCH_PROTECTION.md)).
+- `main` is protected by a ruleset.
 - Work happens on feature branches. PRs only — no direct pushes to `main`.
 - Merges must be squash or rebase. No merge commits.
 - Branch must be up to date with `main` before merging (strict status checks).


### PR DESCRIPTION
## Summary

Syncs two files with the `richwklein/repo-template-base` template following a routine audit. `CONTRIBUTING.md` had a dead link to `docs/BRANCH_PROTECTION.md` (a doc the template no longer ships); this reverts that line to the canonical template wording. `CLAUDE.md` was missing entirely and has been added with the template's default content (`@AGENTS.md`).

## Linked issue

Closes #

## Type of change

_Put an `x` in the boxes that apply._

- [ ] Bug fix
- [ ] Feature
- [x] Maintenance / cleanup
- [x] Documentation / content
- [ ] Breaking change

## Details

- `CONTRIBUTING.md`: reverted the ruleset line from `main is protected by a ruleset (see docs/BRANCH_PROTECTION.md)` back to `main is protected by a ruleset.` — the linked file does not exist in this repo and was removed from the template.
- `CLAUDE.md`: added with the single line `@AGENTS.md` as specified by the template baseline.

No logic changes; no behaviour changes.

## Release / deploy impact

_Put an `x` in the boxes that apply._

- [ ] Preview deploy is useful for reviewing this change
- [x] Safe to label `no-deploy`
- [ ] This PR intentionally updates the version

## Validation

_Put an `x` in the boxes that apply._

- [ ] Lint passes locally
- [ ] Unit tests pass locally
- [ ] Added or updated tests where appropriate
- [ ] Manually verified changes
- [x] Documentation updated where appropriate

## Reviewer notes

Generated by a `/repo-template-audit` run against `richwklein/repo-template-base`. All other drifted files (`.github/dependabot.yml`, `.github/workflows/code-codeql.yaml`, `.vscode/extensions.json`, `.vscode/settings.json`) are intentional Python-project customisations and were left as-is.