### PR TITLE
chore: restore cSpell.words setting in vscode config

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -9,6 +9,7 @@
   "editor.tabSize": 2,
   "editor.formatOnSave": true,
   "editor.wordWrap": "wordWrapColumn",
+  "cSpell.words": ["codeql", "richwklein"],
   "[python]": {
     "editor.tabSize": 4
   },


### PR DESCRIPTION
## Summary

Restores the `cSpell.words` setting to `.vscode/settings.json` that was accidentally dropped when the `[python]` editor configuration was added. The template baseline includes `["codeql", "richwklein"]` as known words for the Code Spell Checker extension; without it, those tokens are flagged as misspellings in the editor.

Surfaced by a `/repo-template-audit` run against `richwklein/repo-template-base`.

## Linked issue

Closes #

## Type of change

- [ ] Bug fix
- [ ] Feature
- [x] Maintenance / cleanup
- [ ] Documentation / content
- [ ] Breaking change

## Details

Single-line addition to `.vscode/settings.json`:

```json
"cSpell.words": ["codeql", "richwklein"],
```

Placed after `editor.wordWrap` and before the `[python]` language-specific block, consistent with the template ordering.

## Release / deploy impact

- [ ] Preview deploy is useful for reviewing this change
- [x] Safe to label `no-deploy`
- [ ] This PR intentionally updates the version

## Validation

- [x] Lint passes locally
- [ ] Unit tests pass locally
- [ ] Added or updated tests where appropriate
- [x] Manually verified changes
- [ ] Documentation updated where appropriate

## Reviewer notes

No logic changes. One-line config restoration caught by template drift audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)