### PR TITLE
fix(release): explicitly disable component in tag name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [0.1.0](https://github.com/richwklein/exif-dates/compare/exif-dates-v0.0.1...exif-dates-v0.1.0) (2026-05-24)
+## [0.1.0](https://github.com/richwklein/exif-dates/compare/v0.0.1...v0.1.0) (2026-05-24)
 
 
 ### Features

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -6,6 +6,7 @@
       "package-name": "exif-dates",
       "changelog-path": "CHANGELOG.md",
       "include-v-in-tag": true,
+      "include-component-in-tag": false,
       "bump-minor-pre-major": true,
       "draft": false,
       "prerelease": false,


### PR DESCRIPTION
## Summary

- Adds `include-component-in-tag: false` to `release-please-config.json`
- Updates the `CHANGELOG.md` compare link to match the renamed `v0.1.0` tag

## Why

Without `include-component-in-tag: false` explicitly set, release-please derives the tag name from `package-name` and produces `exif-dates-v{version}` instead of `v{version}`. The existing `exif-dates-v0.1.0` release and tag have been deleted and recreated as `v0.1.0` to match the canonical format used across all projects.