### PR TITLE
ci: wire detect-relevant-changes into workflows and add Python tooling

### DIFF
--- a/.github/actions/detect-relevant-changes/action.yaml
+++ b/.github/actions/detect-relevant-changes/action.yaml
@@ -1,0 +1,63 @@
+name: "Detect Relevant Changes"
+description: >
+  For pull_request events, sets relevant=true when any changed file matches one
+  of the supplied regex patterns. For any other event (push, schedule,
+  workflow_run, etc.) sets relevant=true unconditionally so heavy work is
+  preserved on main branch and scheduled runs.
+
+inputs:
+  patterns:
+    description: >
+      Multi-line list of JavaScript-compatible regex patterns matched against
+      the full path of each changed file. When empty, falls back to a default
+      set covering workflow and action edits.
+    required: false
+    default: ""
+
+outputs:
+  relevant:
+    description: "true when heavy steps should run; false when the job should noop"
+    value: ${{ steps.detect.outputs.relevant }}
+
+runs:
+  using: "composite"
+  steps:
+    - id: detect
+      uses: actions/github-script@v7
+      env:
+        PATTERNS: ${{ inputs.patterns }}
+      with:
+        script: |
+          const DEFAULT_PATTERNS = [
+            String.raw`^\.github/(workflows|actions)/`,
+            String.raw`\.py$`,
+            String.raw`^pyproject\.toml$`
+          ];
+
+          if (context.eventName !== 'pull_request') {
+            core.info(`Event ${context.eventName}: running heavy work unconditionally.`);
+            core.setOutput('relevant', 'true');
+            return;
+          }
+
+          const raw = (process.env.PATTERNS || '').trim();
+          const sources = raw
+            ? raw.split('\n').map((s) => s.trim()).filter(Boolean)
+            : DEFAULT_PATTERNS;
+          const patterns = sources.map((s) => new RegExp(s));
+
+          const files = await github.paginate(github.rest.pulls.listFiles, {
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            pull_number: context.payload.pull_request.number,
+            per_page: 100,
+          });
+
+          const hit = files.find((f) => patterns.some((p) => p.test(f.filename)));
+          if (hit) {
+            core.info(`Relevant change detected: ${hit.filename}`);
+            core.setOutput('relevant', 'true');
+          } else {
+            core.info(`No relevant changes in ${files.length} files.`);
+            core.setOutput('relevant', 'false');
+          }

--- a/.github/workflows/code-codeql.yaml
+++ b/.github/workflows/code-codeql.yaml
@@ -6,11 +6,12 @@ on:
   pull_request:
     branches: [main]
   schedule:
-    - cron: '23 4 * * 1' # weekly, Monday 04:23 UTC
+    - cron: "23 4 * * 1" # weekly, Monday 04:23 UTC
 
 permissions:
   actions: read
   contents: read
+  pull-requests: read
   security-events: write
 
 jobs:
@@ -29,28 +30,55 @@ jobs:
         #   swift                       -> macos-latest
         #     (Swift extractor only runs on macOS)
         #
+        # PATH FILTERS: The detect-relevant-changes action defaults to
+        # .github/workflows/** and .github/actions/**. When adding a
+        # language entry here, pass the relevant source patterns via the
+        # `patterns` input so the job noop's when nothing important changed.
+        # Per-language pattern selection can be done inline:
+        #   patterns: ${{ matrix.language == 'actions' && '...' || '...' }}
+        #
         # COMPILED LANGUAGES (swift, c-cpp, java-kotlin, csharp) require a
         # build step BEFORE 'Perform CodeQL analysis' so the extractor can
-        # observe source compilation.
+        # observe source compilation. Example for Swift:
+        #
+        #   - name: Build (Swift)
+        #     if: matrix.language == 'swift'
+        #     run: |
+        #       sudo xcode-select -s /Applications/Xcode_16.3.app
+        #       xcodebuild build -project Your.xcodeproj -scheme Your \
+        #         -configuration Debug -destination 'platform=macOS' \
+        #         CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO
         #
         # Each include entry registers its own status check, named
         # `analyze (<language>, <runner>)`. Update branch protection
-        # rulesets to require those exact contexts.
+        # rulesets to require those exact contexts. Keep this matrix
+        # free of extra keys — anything added here becomes part of the
+        # status check name and would break the required-check contexts.
         include:
           - language: actions
             runner: ubuntu-latest
           - language: python
             runner: ubuntu-latest
     steps:
+      # Steps are conditionally skipped rather than the job, so the
+      # matrix-expanded status check (e.g. "analyze (actions, ubuntu-latest)")
+      # is always registered. A job-level skip leaves that check unreported,
+      # which blocks PRs that require it.
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v6.0.3
+
+      - name: Detect relevant changes
+        id: changes
+        uses: ./.github/actions/detect-relevant-changes
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v4.36.0
+        if: steps.changes.outputs.relevant == 'true'
+        uses: github/codeql-action/init@v4.36.1
         with:
           languages: ${{ matrix.language }}
 
       - name: Perform CodeQL analysis
-        uses: github/codeql-action/analyze@v4.36.0
+        if: steps.changes.outputs.relevant == 'true'
+        uses: github/codeql-action/analyze@v4.36.1
         with:
-          category: '/language:${{ matrix.language }}'
+          category: "/language:${{ matrix.language }}"

--- a/.github/workflows/code-lint.yaml
+++ b/.github/workflows/code-lint.yaml
@@ -1,0 +1,30 @@
+name: "Format and Lint"
+on:
+  pull_request:
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: "Checkout source code"
+        uses: actions/checkout@v6.0.3
+
+      - name: "Detect relevant changes"
+        id: changes
+        uses: ./.github/actions/detect-relevant-changes
+
+      - name: "Install dependencies"
+        if: steps.changes.outputs.relevant == 'true'
+        run: pip install ".[dev]"
+
+      - name: "Check formatting"
+        if: always() && steps.changes.outputs.relevant == 'true'
+        run: ruff format --check .
+
+      - name: "Check lint"
+        if: always() && steps.changes.outputs.relevant == 'true'
+        run: ruff check .

--- a/.github/workflows/code-test.yaml
+++ b/.github/workflows/code-test.yaml
@@ -1,0 +1,26 @@
+name: "Test"
+on:
+  pull_request:
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: "Checkout source code"
+        uses: actions/checkout@v6.0.3
+
+      - name: "Detect relevant changes"
+        id: changes
+        uses: ./.github/actions/detect-relevant-changes
+
+      - name: "Install dependencies"
+        if: steps.changes.outputs.relevant == 'true'
+        run: pip install ".[dev]"
+
+      - name: "Run tests"
+        if: steps.changes.outputs.relevant == 'true'
+        run: python3 -m pytest tests/

--- a/.github/workflows/release-please.yaml
+++ b/.github/workflows/release-please.yaml
@@ -1,4 +1,7 @@
 name: Release
+# No paths filter: release-please must see every push to main so it can
+# parse conventional commits and drive version bumps. Filtering by path
+# would silently skip commits and break the release train.
 on:
   push:
     branches: [main]

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,12 @@ dist/
 build/
 out/
 .cache/
+*.egg-info/
+
+# python
+__pycache__/
+*.py[cod]
+.pytest_cache/
 
 # dependencies
 node_modules/

--- a/exif_dates.py
+++ b/exif_dates.py
@@ -1,31 +1,33 @@
 import argparse
 import glob
-import os
 import logging
+import shutil
 import subprocess
 import sys
-import shutil
-from pathlib import Path
-from datetime import datetime, timedelta
-from datetime import date
-from datetime import time
+from datetime import datetime, time, timedelta
 
 FILE_EXTENSIONS = ("mp4", "lrv", "jpg", "thm")
 DATE_FORMAT = "%Y-%m-%d"
-DATETIME_FORMAT = "{} %H:%M:%S".format(DATE_FORMAT)
+DATETIME_FORMAT = f"{DATE_FORMAT} %H:%M:%S"
 GET_DATE_PROCESS = 'exiftool -d "{0}" -CreateDate -S -s "{1}"'
-DEFAULT_TIME = time(12,0,0)
-SET_DATE_PROCESS = 'exiftool -AllDates="{0}" -TrackCreateDate="{0}" -TrackModifyDate="{0}" -MediaCreateDate="{0}" -MediaModifyDate="{0}" -overwrite_original "{1}";'
+DEFAULT_TIME = time(12, 0, 0)
+SET_DATE_PROCESS = (
+    'exiftool -AllDates="{0}" -TrackCreateDate="{0}" -TrackModifyDate="{0}"'
+    ' -MediaCreateDate="{0}" -MediaModifyDate="{0}" -overwrite_original "{1}";'
+)
 
 logging.basicConfig(stream=sys.stdout, level=logging.INFO)
+
 
 def insensitive_glob(directory, ext):
     """
     Implements a case insensitive glob to find files of a given extension in a directory.
     """
+
     def either(c):
-        return '[%s%s]' % (c.lower(), c.upper()) if c.isalpha() else c
-    return glob.glob('{0}/*.{1}'.format(directory, ''.join(map(either, ext))))
+        return f"[{c.lower()}{c.upper()}]" if c.isalpha() else c
+
+    return glob.glob("{}/*.{}".format(directory, "".join(map(either, ext))))
 
 
 def has_exiftool():
@@ -37,29 +39,37 @@ def has_exiftool():
 
 def process_file(path, new_date, time_delta, dry_run):
     """
-    Extracts the dates from the file. It then merges the new date with the old date's timedelta 
-    and overwrites all the exif dates. 
+    Extracts the dates from the file. It then merges the new date with the old date's timedelta
+    and overwrites all the exif dates.
     """
-    logging.info("Processing: {}".format(path))
+    logging.info(f"Processing: {path}")
 
     # Get the original date by pulling the CreateDate tag in the desired format
-    output = subprocess.check_output(GET_DATE_PROCESS.format(DATETIME_FORMAT, path), stderr=subprocess.STDOUT, shell=True)
+    output = subprocess.check_output(
+        GET_DATE_PROCESS.format(DATETIME_FORMAT, path), stderr=subprocess.STDOUT, shell=True
+    )
     created_exif = output.rstrip().decode("utf-8")
     try:
         created_datetime = datetime.strptime(created_exif, DATETIME_FORMAT)
-    except Exception as e:
+    except Exception:
         created_datetime = None
 
     # Calculate the new date and time
     if created_datetime is None:
         new_datetime = datetime.combine(new_date, DEFAULT_TIME)
     else:
-        new_datetime = datetime.combine(new_date, created_datetime.time()) + timedelta(seconds=time_delta*60)
+        new_datetime = datetime.combine(new_date, created_datetime.time()) + timedelta(
+            seconds=time_delta * 60
+        )
 
     # Replace the all the known date tags with new ones and overwrite the file
-    logging.info("Setting date from: {} to: {}".format(created_datetime, new_datetime))
+    logging.info(f"Setting date from: {created_datetime} to: {new_datetime}")
     if not dry_run:
-        output = subprocess.check_output(SET_DATE_PROCESS.format(new_datetime.strftime(DATETIME_FORMAT), path), stderr=subprocess.STDOUT, shell=True)
+        output = subprocess.check_output(
+            SET_DATE_PROCESS.format(new_datetime.strftime(DATETIME_FORMAT), path),
+            stderr=subprocess.STDOUT,
+            shell=True,
+        )
         logging.debug(output.rstrip().decode("utf-8"))
 
 
@@ -67,7 +77,7 @@ def process_files(directory, new_date, time_delta, dry_run):
     """
     Scan the given directory for the files we are interested in.
     """
-    logging.info("Scanning for media in: {}".format(directory))
+    logging.info(f"Scanning for media in: {directory}")
 
     for ext in FILE_EXTENSIONS:
         for path in insensitive_glob(directory, ext):
@@ -76,27 +86,33 @@ def process_files(directory, new_date, time_delta, dry_run):
 
 def main():
     """
-    Parse the command line arguments and execute if the exiftool is found. 
+    Parse the command line arguments and execute if the exiftool is found.
     """
-    parser = argparse.ArgumentParser(description='Process a directory of images and update the exif dates.')
-    parser.add_argument('directory', type=str, help='Full path to the directory to process.')
-    parser.add_argument('--date', type=str, help='New date in the YYYY-MM-DD format.', default=datetime.now().strftime(DATE_FORMAT))
-    parser.add_argument('--delta', type=int, help='Time delta in minutes.', default=0)
-    parser.add_argument('--dry', help="Execute as a dry run with no updates.", action="store_true")
-    
+    parser = argparse.ArgumentParser(
+        description="Process a directory of images and update the exif dates."
+    )
+    parser.add_argument("directory", type=str, help="Full path to the directory to process.")
+    parser.add_argument(
+        "--date",
+        type=str,
+        help="New date in the YYYY-MM-DD format.",
+        default=datetime.now().strftime(DATE_FORMAT),
+    )
+    parser.add_argument("--delta", type=int, help="Time delta in minutes.", default=0)
+    parser.add_argument("--dry", help="Execute as a dry run with no updates.", action="store_true")
+
     if not has_exiftool():
         sys.exit("exiftool was not found")
-    
+
     args = parser.parse_args()
     new_date = datetime.strptime(args.date, DATE_FORMAT).date()
 
-    logging.info("Setting new dates to '{}' with time delta {}".format(new_date, args.delta))
+    logging.info(f"Setting new dates to '{new_date}' with time delta {args.delta}")
 
     process_files(args.directory, new_date, args.delta, args.dry)
     sys.exit(0)
 
+
 if __name__ == "__main__":
     # execute only if run as a script
     main()
-
-    

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,17 @@
+[project]
+name = "exif-dates"
+version = "0.1.1"
+requires-python = ">=3.12"
+
+[project.optional-dependencies]
+dev = ["pytest>=9.0", "ruff>=0.9"]
+
+[tool.ruff]
+line-length = 100
+target-version = "py312"
+
+[tool.ruff.lint]
+select = ["E", "F", "I", "UP"]
+
+[tool.ruff.format]
+quote-style = "double"

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -10,7 +10,7 @@
       "bump-minor-pre-major": true,
       "draft": false,
       "prerelease": false,
-      "extra-files": ["version.txt"]
+      "extra-files": ["version.txt", "pyproject.toml"]
     }
   }
 }

--- a/tests/test_exif_dates.py
+++ b/tests/test_exif_dates.py
@@ -1,0 +1,42 @@
+from pathlib import Path
+
+from exif_dates import has_exiftool, insensitive_glob
+
+
+def test_has_exiftool_returns_bool():
+    assert isinstance(has_exiftool(), bool)
+
+
+class TestInsensitiveGlob:
+    def test_matches_lowercase_extension(self, tmp_path):
+        (tmp_path / "photo.jpg").touch()
+        assert tmp_path / "photo.jpg" in [Path(p) for p in insensitive_glob(tmp_path, "jpg")]
+
+    def test_matches_uppercase_extension(self, tmp_path):
+        (tmp_path / "photo.JPG").touch()
+        result = insensitive_glob(tmp_path, "jpg")
+        assert len(result) == 1
+
+    def test_matches_mixed_case_extension(self, tmp_path):
+        (tmp_path / "clip.Mp4").touch()
+        result = insensitive_glob(tmp_path, "mp4")
+        assert len(result) == 1
+
+    def test_no_match_returns_empty(self, tmp_path):
+        (tmp_path / "document.txt").touch()
+        result = insensitive_glob(tmp_path, "jpg")
+        assert result == []
+
+    def test_excludes_subdirectory_files(self, tmp_path):
+        subdir = tmp_path / "sub"
+        subdir.mkdir()
+        (subdir / "photo.jpg").touch()
+        result = insensitive_glob(tmp_path, "jpg")
+        assert result == []
+
+    def test_multiple_matches(self, tmp_path):
+        (tmp_path / "a.jpg").touch()
+        (tmp_path / "b.JPG").touch()
+        (tmp_path / "c.Jpg").touch()
+        result = insensitive_glob(tmp_path, "jpg")
+        assert len(result) == 3


### PR DESCRIPTION
## Summary

- Adds `.github/actions/detect-relevant-changes` composite action with repo-specific default patterns (`\.py$`, `pyproject\.toml`, `.github/`) so heavy CI steps noop on PRs that don't touch relevant files
- Wires the action into `code-codeql.yaml` (restores `pull-requests: read` permission, adds per-step `if:` guards, updates action pins to match skills repo)
- Adds `code-lint.yaml` and `code-test.yaml`, aligned with the skills repo structure
- Adds `pyproject.toml` with ruff and pytest dev dependencies; registers it in release-please `extra-files`
- Applies ruff formatting and lint fixes to `exif_dates.py` (f-strings, import cleanup, line length)
- Adds unit tests for `insensitive_glob` and `has_exiftool`
- Extends `.gitignore` with standard Python entries

## Test plan

- [ ] `code-lint` workflow passes on this PR
- [ ] `code-test` workflow passes on this PR
- [ ] `analyze (actions, ubuntu-latest)` CodeQL check passes
- [ ] `analyze (python, ubuntu-latest)` CodeQL check passes
- [ ] Open a follow-up PR touching only a markdown file and confirm lint/test/codeql all noop via the detect-relevant-changes output

🤖 Generated with [Claude Code](https://claude.com/claude-code)