### PR TITLE
chore(audit): sync files with repo-template-base

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,9 +10,12 @@ updates:
     labels:
       - 'dependencies'
     groups:
-      github-actions:
+      first-party-actions:
         patterns:
-          - '*'
+          - 'actions/*'
+      third-party-actions:
+        exclude-patterns:
+          - 'actions/*'
 
   - package-ecosystem: pip
     directory: '/'

--- a/.github/labels.json
+++ b/.github/labels.json
@@ -1,0 +1,9 @@
+[
+  { "name": "idea",            "color": "c5def5", "description": "Rough idea or note captured for later." },
+  { "name": "bug",             "color": "d73a4a", "description": "Something isn't working." },
+  { "name": "enhancement",     "color": "a2eeef", "description": "New capability or meaningful improvement." },
+  { "name": "task",            "color": "e4e669", "description": "Upkeep, refactoring, cleanup, docs, or process work." },
+  { "name": "documentation",   "color": "0075ca", "description": "Improvements or additions to documentation." },
+  { "name": "dependencies",    "color": "0366d6", "description": "Dependency version updates." },
+  { "name": "breaking-change", "color": "b60205", "description": "Introduces a backwards-incompatible change." }
+]

--- a/.github/workflows/code-codeql.yaml
+++ b/.github/workflows/code-codeql.yaml
@@ -65,7 +65,7 @@ jobs:
       # is always registered. A job-level skip leaves that check unreported,
       # which blocks PRs that require it.
       - name: Checkout
-        uses: actions/checkout@v7.0.0
+        uses: actions/checkout@v7
 
       - name: Detect relevant changes
         id: changes
@@ -73,12 +73,12 @@ jobs:
 
       - name: Initialize CodeQL
         if: steps.changes.outputs.relevant == 'true'
-        uses: github/codeql-action/init@v4.36.2
+        uses: github/codeql-action/init@v4.36.3
         with:
           languages: ${{ matrix.language }}
 
       - name: Perform CodeQL analysis
         if: steps.changes.outputs.relevant == 'true'
-        uses: github/codeql-action/analyze@v4.36.2
+        uses: github/codeql-action/analyze@v4.36.3
         with:
           category: "/language:${{ matrix.language }}"

--- a/.github/workflows/pr-labeler.yaml
+++ b/.github/workflows/pr-labeler.yaml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Apply labels from branch prefix
-        uses: actions/labeler@v6.1.0
+        uses: actions/labeler@v6
         with:
           configuration-path: .github/labeler.yml
           sync-labels: true

--- a/.github/workflows/release-please.yaml
+++ b/.github/workflows/release-please.yaml
@@ -17,10 +17,10 @@ jobs:
       - uses: actions/create-github-app-token@v3
         id: app-token
         with:
-          app-id: ${{ secrets.RELEASE_BOT_APP_ID }}
+          client-id: ${{ secrets.RELEASE_BOT_CLIENT_ID }}
           private-key: ${{ secrets.RELEASE_BOT_PRIVATE_KEY }}
 
-      - uses: googleapis/release-please-action@v5
+      - uses: googleapis/release-please-action@v5.0.0
         with:
           token: ${{ steps.app-token.outputs.token }}
           config-file: release-please-config.json

--- a/.github/workflows/seed-labels.yaml
+++ b/.github/workflows/seed-labels.yaml
@@ -1,0 +1,30 @@
+name: Seed labels
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - '.github/labels.json'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  seed:
+    name: seed
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Create or update labels
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          jq -c '.[]' .github/labels.json | while IFS= read -r label; do
+            name=$(jq -r '.name' <<< "$label")
+            color=$(jq -r '.color' <<< "$label")
+            description=$(jq -r '.description' <<< "$label")
+            gh label create "$name" --color "$color" --description "$description" --force
+          done


### PR DESCRIPTION
## Summary

Sync template-tracked files with `repo-template-base` following a drift audit (`/repo-template-audit`).

## Linked issue

Closes #

## Motivation

The base template changed its action versioning strategy (first-party actions pinned to major version, third-party to full patch) and added a canonical label seeding mechanism. This repo had drifted behind on those changes.

## Changes

- **New from template:** `.github/labels.json` (canonical label definitions) and `.github/workflows/seed-labels.yaml` (seeds labels on change to the JSON or manual dispatch).
- **`dependabot.yml`:** actions grouping split into `first-party-actions` (`actions/*`) and `third-party-actions`, matching the new versioning strategy. Local `pip` ecosystem block kept.
- **`code-codeql.yaml`:** `actions/checkout@v7` (major-only), `github/codeql-action@v4.36.3` (full patch). Local Python matrix entry kept; status checks still always register since skipping is step-level.
- **`pr-labeler.yaml`:** fast-forward to template — `actions/labeler@v6` (major-only).
- **`release-please.yaml`:** fast-forward to template — `googleapis/release-please-action@v5.0.0` (full patch) and app token switched from `app-id` to `client-id`.

Local Python tooling (detect-relevant-changes patterns, `.gitignore`/`.vscode` entries) intentionally kept — the base template has no Python support.

## Validation

_Put an `x` in the boxes that apply._

- [x] Lint passes locally
- [ ] Unit tests pass locally
- [x] Behavior is unchanged (refactor) or covered by existing/new tests
- [x] Manually verified where applicable

## Release / deploy impact

_Put an `x` in the boxes that apply._

- [ ] Preview deploy is useful for reviewing this change
- [x] Safe to label `no-deploy`
- [ ] Breaking change (also apply the `breaking-change` label)

## Reviewer notes

⚠️ **Before merging:** add the `RELEASE_BOT_CLIENT_ID` secret (the GitHub App's client ID) — the synced release workflow reads it and the repo currently only has `RELEASE_BOT_APP_ID`:

```bash
gh secret set RELEASE_BOT_CLIENT_ID --repo richwklein/exif-dates
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)